### PR TITLE
[PLAT-1018] Adding explicit Token minimal permissions to all workflows as we are switching to “restrict-mode”

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -3,6 +3,9 @@ on:
         branches:
             - main
 
+permissions:
+    contents: read       # Required for actions/checkout
+
 jobs:
     prerelease:
         runs-on: ubuntu-latest

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,5 +1,9 @@
 name: Check
 on: [pull_request]
+
+permissions:
+    contents: read       # Required for actions/checkout
+
 jobs:
   check:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,9 @@ on:
         tags:
           - 'v*.*.*'
 
+permissions:
+    contents: read       # Required for actions/checkout
+
 jobs:
     prerelease:
         runs-on: ubuntu-latest


### PR DESCRIPTION
## Hi everyone, 
Greetings from the Cloud Engineering team :wave:
We're raising this PR to address the following changes:
By default GitHub gives the `GITHUB_TOKEN` full permissions (read/write), and we are going to change this to be
more restrictive - in this case we're switching it to Read access. Limiting the Token to be restricted by default significantly increases our pipeline security!
What does this mean to you ? It means from the moment we turn this on (we're aiming for 1st of Feb.), your custom actions will probably start to fail.
To prevent this from happening you need to:
* make sure all your custom actions have the necessary permissions added
* make sure all your third party actions have the permissions they need added as well
On this PR we are adding some permissions that we quickly identified as needed, but it might not cover all of them.
When you add the permissions you believe will cover everything, if you want to test them, you can turn the feature on for your repo at `repo settings > actions > workflow permissions` :  
<a href="https://ibb.co/6NpsphF"><img src="https://i.ibb.co/7bTyTcK/Screenshot-2022-01-14-at-13-26-14.png" alt="Screenshot-2022-01-14-at-13-26-14" border="0"></a>
----------
You can read more about this [here](https://docs.github.com/en/actions/security-guides/automatic-token-authentication).  
Feel free to reach out to us if you have any questions! 