### PR TITLE
Add InvocationRecord support

### DIFF
--- a/src/aws/anyEvent.ts
+++ b/src/aws/anyEvent.ts
@@ -1,16 +1,59 @@
 import {
   APIGatewayProxyEvent,
-  SNSEventRecord,
-  SNSEvent,
-  CloudFrontRequest,
   CloudFrontEvent,
+  CloudFrontRequest,
   CloudFrontRequestEvent,
-  EventBridgeEvent,
   DynamoDBRecord,
   DynamoDBStreamEvent,
+  EventBridgeEvent,
+  SNSEvent,
+  SNSEventRecord,
   SQSEvent,
   SQSRecord,
 } from 'aws-lambda';
+
+interface InvocationRecordOnSuccess<Response, Request = unknown> {
+  requestContext: {
+    approximateInvokeCount: number;
+    condition: string;
+    functionArn: string;
+    requestId: string;
+  };
+  requestPayload: Request;
+  responseContext: {
+    executedVersion: string;
+    statusCode: number;
+  };
+  responsePayload: Response;
+  timestamp: string;
+  version: string;
+}
+
+interface InvocationRecordOnFailure<Request = unknown> {
+  requestContext: {
+    approximateInvokeCount: number;
+    condition: string;
+    functionArn: string;
+    requestId: string;
+  };
+  requestPayload: Request;
+  responseContext: {
+    executedVersion: string;
+    functionError: string;
+    statusCode: number;
+  };
+  responsePayload: {
+    errorMessage: string;
+    errorType: string;
+    stackTrace: string[];
+  };
+  timestamp: string;
+  version: string;
+}
+
+export type InvocationRecord<Response, Request = unknown> =
+  | InvocationRecordOnFailure<Request>
+  | InvocationRecordOnSuccess<Response, Request>;
 
 export type AnyEvent =
   | SNSEvent
@@ -19,7 +62,8 @@ export type AnyEvent =
   | EventBridgeEvent<string, unknown>
   | DynamoDBStreamEvent
   | SQSEvent
-  | SQSRecord;
+  | SQSRecord
+  | InvocationRecord<unknown>;
 
 type CloudfrontRecord = {
   cf: CloudFrontEvent & {

--- a/src/aws/index.ts
+++ b/src/aws/index.ts
@@ -8,6 +8,7 @@ import {forDynamo} from './dynamodb';
 import {LambdaContext} from './context';
 import {forEventBridge, EventBridgeContext} from './eventbridge';
 import {AnyEvent} from './anyEvent';
+import {forInvocationRecord} from './invocationRecord';
 
 const UNKNOWN = 'unknown';
 
@@ -31,6 +32,7 @@ function fromContext(event: AnyEvent, ctx: Context, options = {}) {
     forCloudFront(event, ctx, options) ||
     forDynamo(event, ctx, options) ||
     forSqs(event, ctx, options) ||
+    forInvocationRecord(event, ctx, options) ||
     empty();
   return PinoLogger(options, context);
 }

--- a/src/aws/invocationRecord.ts
+++ b/src/aws/invocationRecord.ts
@@ -1,0 +1,44 @@
+import {AnyEvent, InvocationRecord} from './anyEvent';
+import {ContextInfo, LambdaContext, makeContext} from './context';
+import {Context} from 'aws-lambda';
+import {LoggerOptions} from '../core';
+
+export function isInvocationRecord(
+  event: AnyEvent
+): event is InvocationRecord<unknown> {
+  return 'responseContext' in event;
+}
+
+interface InvocationRecordContext extends Record<string, unknown> {
+  trigger: 'LambdaDestination';
+  source: {
+    function_arn: string;
+    kind: 'OnSuccess' | 'OnFailure';
+    request_id: string;
+    timestamp: string;
+    version: string;
+  };
+}
+
+function getIsOnSuccess({responseContext}: InvocationRecord<unknown>): boolean {
+  return !('functionError' in responseContext);
+}
+
+export function forInvocationRecord(
+  event: AnyEvent,
+  context: Context,
+  options: Partial<LoggerOptions>
+): LambdaContext | undefined {
+  if (!isInvocationRecord(event)) return;
+
+  return makeContext<ContextInfo, InvocationRecordContext>(context, options, {
+    trigger: 'LambdaDestination',
+    source: {
+      function_arn: event.requestContext.functionArn,
+      kind: getIsOnSuccess(event) ? 'OnSuccess' : 'OnFailure',
+      request_id: event.requestContext.requestId,
+      timestamp: event.timestamp,
+      version: event.version,
+    },
+  });
+}

--- a/test/data/invocationRecord.ts
+++ b/test/data/invocationRecord.ts
@@ -1,0 +1,54 @@
+import {InvocationRecord} from '../../src/aws/anyEvent';
+import {baseContext} from './baseContext';
+
+export const context = {
+  ...baseContext,
+  invokedFunctionArn:
+    'arn:aws:lambda:region:account-id:function:function-name:alias-name',
+  functionName: 'my-function',
+  functionVersion: 'v1.0.1',
+  awsRequestId: 'request-id',
+  logGroupName: 'log-group',
+  logStreamName: 'log-stream',
+};
+
+export const onSuccess: InvocationRecord<{data: number}, {input: string}> = {
+  requestContext: {
+    approximateInvokeCount: 2,
+    condition: 'condition',
+    functionArn:
+      'arn:aws:lambda:region:account-id:function:source-function-name:alias-name',
+    requestId: 'source-request-id',
+  },
+  requestPayload: {input: 'some-data'},
+  responseContext: {
+    executedVersion: 'v1.1.0',
+    statusCode: 200,
+  },
+  responsePayload: {data: 42},
+  timestamp: '2022-01-01',
+  version: 'v1.1.0',
+};
+
+export const onFailure: InvocationRecord<{data: number}, {input: string}> = {
+  requestContext: {
+    approximateInvokeCount: 3,
+    condition: 'condition',
+    functionArn:
+      'arn:aws:lambda:region:account-id:function:source-function-name:alias-name',
+    requestId: 'source-request-id',
+  },
+  requestPayload: {input: 'some-data'},
+  responseContext: {
+    executedVersion: 'v1.1.0',
+    statusCode: 500,
+    functionError: 'Error',
+  },
+  responsePayload: {
+    errorMessage: 'Something went wrong',
+    errorType: 'Error',
+    stackTrace: ['On line 1', 'On line 34'],
+  },
+  timestamp: '2022-01-01',
+  version: 'v1.1.0',
+};

--- a/test/fluentContext.test.ts
+++ b/test/fluentContext.test.ts
@@ -2,7 +2,7 @@ import * as logger from '../src';
 import {once, sink} from './helper';
 import * as sns from './data/sns';
 
-describe('When setting context', async () => {
+describe('When setting context', () => {
   it('Should include context in output', async () => {
     const stream = sink();
 
@@ -30,7 +30,7 @@ describe('When setting context', async () => {
   });
 });
 
-describe('When setting context twice', async () => {
+describe('When setting context twice', () => {
   it('Should extend existing context', async () => {
     const stream = sink();
 

--- a/test/invocationRecord.test.ts
+++ b/test/invocationRecord.test.ts
@@ -1,0 +1,88 @@
+import * as logger from '../src';
+import {sink} from './helper';
+import {onSuccess, context, onFailure} from './data/invocationRecord';
+
+describe('When logging in an invocation record context', () => {
+  const now = Date.now();
+  const dateSpy = jest.spyOn(Date, 'now').mockImplementation(() => now);
+
+  afterAll(() => {
+    dateSpy.mockRestore();
+  });
+
+  describe('When from successful invocation', () => {
+    beforeEach(async () => {});
+
+    it('should log the hello world message', async () => {
+      const stream = sink(true);
+
+      const p = new Promise<string>(resolve => {
+        stream.on('data', resolve);
+      });
+
+      const log = logger.fromContext(onSuccess, context, {stream});
+      log.info('Hello world');
+      const result = JSON.parse(await p);
+
+      expect(result).toStrictEqual({
+        level: 'info',
+        context: {
+          request_id: context.awsRequestId,
+          account_id: 'account-id',
+          function: {
+            name: context.functionName,
+            version: context.functionVersion,
+            service: 'Unknown',
+          },
+          source: {
+            function_arn:
+              'arn:aws:lambda:region:account-id:function:source-function-name:alias-name',
+            kind: 'OnSuccess',
+            request_id: 'source-request-id',
+            timestamp: '2022-01-01',
+            version: 'v1.1.0',
+          },
+          trigger: 'LambdaDestination',
+        },
+        msg: 'Hello world',
+      });
+    });
+  });
+
+  describe('When from failed invocation', () => {
+    it('should log the hello world message', async () => {
+      const stream = sink(true);
+
+      const p = new Promise<string>(resolve => {
+        stream.on('data', resolve);
+      });
+
+      const log = logger.fromContext(onFailure, context, {stream});
+      log.info('Hello world');
+      const result = JSON.parse(await p);
+
+      expect(result).toStrictEqual({
+        level: 'info',
+        context: {
+          request_id: context.awsRequestId,
+          account_id: 'account-id',
+          function: {
+            name: context.functionName,
+            version: context.functionVersion,
+            service: 'Unknown',
+          },
+          source: {
+            function_arn:
+              'arn:aws:lambda:region:account-id:function:source-function-name:alias-name',
+            kind: 'OnFailure',
+            request_id: 'source-request-id',
+            timestamp: '2022-01-01',
+            version: 'v1.1.0',
+          },
+          trigger: 'LambdaDestination',
+        },
+        msg: 'Hello world',
+      });
+    });
+  });
+});


### PR DESCRIPTION
This PR adds support for invocation records, which are raised when you connect two Lambda functions using Lambda Destinations. Note that I've been forced to manually create the invocation record type! `@types/aws-lambda' doesn't seem to have a corresponding type definition. I've raised an issue in that repository [here](https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/59410).