### PR TITLE
[add-support-for-s3-events] support for s3 events and s3 event records

### DIFF
--- a/src/aws/anyEvent.ts
+++ b/src/aws/anyEvent.ts
@@ -7,6 +7,8 @@ import {
   DynamoDBRecord,
   DynamoDBStreamEvent,
   EventBridgeEvent,
+  S3Event,
+  S3EventRecord,
   SNSEvent,
   SNSEventRecord,
   SQSEvent,
@@ -65,7 +67,9 @@ export type AnyEvent =
   | DynamoDBStreamEvent
   | SQSEvent
   | SQSRecord
-  | InvocationRecord<unknown>;
+  | InvocationRecord<unknown>
+  | S3Event
+  | S3EventRecord;
 
 type CloudfrontRecord = {
   cf: CloudFrontEvent & {

--- a/src/aws/index.ts
+++ b/src/aws/index.ts
@@ -10,6 +10,7 @@ import {LambdaContext} from './context';
 import {forEventBridge, EventBridgeContext} from './eventbridge';
 import {AnyEvent} from './anyEvent';
 import {forInvocationRecord} from './invocationRecord';
+import {forS3} from './s3';
 
 const UNKNOWN = 'unknown';
 
@@ -34,6 +35,7 @@ function fromContext(event: AnyEvent, ctx: Context, options = {}) {
     forCloudFront(event, ctx, options) ||
     forDynamo(event, ctx, options) ||
     forSqs(event, ctx, options) ||
+    forS3(event, ctx, options) ||
     forInvocationRecord(event, ctx, options) ||
     empty();
   return PinoLogger(options, context);

--- a/src/aws/s3.ts
+++ b/src/aws/s3.ts
@@ -1,0 +1,39 @@
+import {Context, S3Event, S3EventRecord} from 'aws-lambda';
+import {LambdaContext, makeContext} from './context';
+import {LoggerOptions} from '../core';
+import {AnyEvent, AnyRecord} from './anyEvent';
+
+export function isS3Record(
+  record: AnyRecord | AnyEvent
+): record is S3EventRecord {
+  return 's3' in record;
+}
+
+function isS3Event(event: AnyEvent): event is S3Event {
+  if (!('Records' in event)) return false;
+  if (!Array.isArray(event.Records)) return false;
+  return event.Records.length > 0 && isS3Record(event.Records[0]);
+}
+
+function ctx(
+  record: S3EventRecord,
+  context: Context,
+  options: Partial<LoggerOptions>
+): LambdaContext | undefined {
+  return makeContext(context, options, {
+    s3: {
+      bucketName: record.s3.bucket.name,
+      key: record.s3.object.key,
+    },
+  });
+}
+
+export function forS3(
+  event: AnyEvent,
+  context: Context,
+  options: Partial<LoggerOptions>
+): LambdaContext | undefined {
+  if (isS3Event(event)) return ctx(event.Records[0], context, options);
+  if (isS3Record(event)) return ctx(event, context, options);
+  return;
+}

--- a/test/data/s3.ts
+++ b/test/data/s3.ts
@@ -1,0 +1,48 @@
+import {baseContext} from './baseContext';
+
+export const record = {
+  eventVersion: '2.0',
+  eventSource: 'aws:s3',
+  awsRegion: 'us-east-1',
+  eventTime: '1970-01-01T00:00:00.000Z',
+  eventName: 'ObjectCreated:Put',
+  userIdentity: {
+    principalId: 'EXAMPLE',
+  },
+  requestParameters: {
+    sourceIPAddress: '127.0.0.1',
+  },
+  responseElements: {
+    'x-amz-request-id': 'EXAMPLE123456789',
+    'x-amz-id-2':
+      'EXAMPLE123/5678abcdefghijklambdaisawesome/mnopqrstuvwxyzABCDEFGH',
+  },
+  s3: {
+    s3SchemaVersion: '1.0',
+    configurationId: 'testConfigRule',
+    bucket: {
+      name: 'example-bucket',
+      ownerIdentity: {
+        principalId: 'EXAMPLE',
+      },
+      arn: 'arn:aws:s3:::example-bucket',
+    },
+    object: {
+      key: 'test%2Fkey',
+      size: 1024,
+      eTag: '0123456789abcdef0123456789abcdef',
+      sequencer: '0A1B2C3D4E5F678901',
+    },
+  },
+};
+
+export const context = {
+  ...baseContext,
+  invokedFunctionArn:
+    'arn:aws:lambda:region:account-id:function:function-name:alias-name',
+  functionName: 'my-function',
+  functionVersion: 'v1.0.1',
+  awsRequestId: 'request-id',
+  logGroupName: 'log-group',
+  logStreamName: 'log-stream',
+};

--- a/test/s3.test.ts
+++ b/test/s3.test.ts
@@ -1,0 +1,30 @@
+import * as logger from '../src';
+import {sink, once} from './helper';
+import {record, context} from './data/s3';
+
+it('When logging in an S3 event context', async () => {
+  const stream = sink();
+
+  const log = logger.fromContext(record, context, {stream});
+  log.info('Hello world');
+
+  const result = await once(stream);
+
+  expect(result).toStrictEqual({
+    level: 'info',
+    context: {
+      request_id: context.awsRequestId,
+      account_id: 'account-id',
+      function: {
+        name: context.functionName,
+        version: context.functionVersion,
+        service: 'Unknown',
+      },
+      s3: {
+        bucketName: record.s3.bucket.name,
+        key: record.s3.object.key,
+      },
+    },
+    msg: 'Hello world',
+  });
+});


### PR DESCRIPTION
This PR introduces support for handling S3 events within the AnyEvent of the Cazoo logger. Prior to this change, AnyEvent was not equipped to handle S3 event triggers. By adding this functionality, we can now integrate and respond to events originating from S3. 